### PR TITLE
add maxHeights to graphql queries

### DIFF
--- a/src/pages/about-me.js
+++ b/src/pages/about-me.js
@@ -64,7 +64,7 @@ query AboutMeQuery {
               }
             }
             image {
-                fluid(maxWidth: 500, background: "rgb:000000") {
+                fluid(maxWidth: 500, maxHeight: 500, background: "rgb:000000") {
                   ...GatsbyContentfulFluid_tracedSVG
                 }
               }

--- a/src/templates/project-post.js
+++ b/src/templates/project-post.js
@@ -76,7 +76,7 @@ export const pageQuery = graphql`
              json
             }
             toolsUsed{
-             fluid( maxWidth: 48) {
+             fluid( maxWidth: 48, maxHeight: 48) {
                 ...GatsbyContentfulFluid_tracedSVG
                 }
             description


### PR DESCRIPTION
attempt adding maxHeights to queries in to prevent `vips2png: unable to write to target error`